### PR TITLE
Copy time parts before modifying for copy constructor

### DIFF
--- a/Piece.pm
+++ b/Piece.pm
@@ -109,10 +109,11 @@ sub _mktime {
            ? ref $class
            : $class;
     if (ref($time)) {
-        my @tm_parts = (@{$time}[c_sec .. c_mon], $time->[c_year]+1900);
-        $time->[c_epoch] = $islocal ? timelocal(@tm_parts) : timegm(@tm_parts);
+        my @new_time = @$time;
+        my @tm_parts = (@new_time[c_sec .. c_mon], $new_time[c_year]+1900);
+        $new_time[c_epoch] = $islocal ? timelocal(@tm_parts) : timegm(@tm_parts);
 
-        return wantarray ? @$time : bless [@$time[0..9], $islocal], $class;
+        return wantarray ? @new_time : bless [@new_time[0..9], $islocal], $class;
     }
     _tzset();
     my @time = $islocal ?


### PR DESCRIPTION
The only time _mktime is called with an array reference not created internally is when using the copy constructor: `Time::Piece->new($obj)`. In this instance, the epoch field of `$obj` was inadvertently modified before copying the values to the new object.