### PR TITLE
Respect islocal of existing object in copy constructor

### DIFF
--- a/Piece.pm
+++ b/Piece.pm
@@ -71,7 +71,10 @@ sub new {
 
     my $self;
 
-    if (defined($time)) {
+    if (ref($time)) {
+        $self = $time->[c_islocal] ? $class->localtime($time) : $class->gmtime($time);
+    }
+    elsif (defined($time)) {
         $self = $class->localtime($time);
     }
     elsif (ref($class) && $class->isa(__PACKAGE__)) {

--- a/t/01base.t
+++ b/t/01base.t
@@ -1,4 +1,4 @@
-use Test::More tests => 13;
+use Test::More tests => 15;
 
 BEGIN { use_ok('Time::Piece'); }
 
@@ -37,3 +37,8 @@ isa_ok($l, 'Time::Piece', 'custom localtime via new again');
 my $l_clone = Time::Piece->new($l);
 isa_ok($l, 'Time::Piece', 'custom localtime via clone');
 cmp_ok("$l_clone", 'eq', "$l", 'Clones match');
+
+#via clone with gmtime
+my $g_clone = Time::Piece->new($g);
+isa_ok($g, 'Time::Piece', 'custom gmtime via clone');
+cmp_ok("$g_clone", 'eq', "$g", 'Clones match');


### PR DESCRIPTION
When Time::Piece->new($obj) is called on a UTC Time::Piece object, it would be passed unconditionally to localtime, resulting in the wrong time being set in the copy.