### PR TITLE
Switch Time::Piece to XSLoader

### DIFF
--- a/Piece.pm
+++ b/Piece.pm
@@ -2,13 +2,11 @@ package Time::Piece;
 
 use strict;
 
-require DynaLoader;
+use XSLoader ();
 use Time::Seconds;
 use Carp;
 use Time::Local;
 
-our @ISA = qw(DynaLoader);
- 
 use Exporter ();
 
 our @EXPORT = qw(
@@ -22,7 +20,7 @@ our %EXPORT_TAGS = (
 
 our $VERSION = '1.3202';
 
-bootstrap Time::Piece $VERSION;
+XSLoader::load( 'Time::Piece', $VERSION );
 
 my $DATE_SEP = '-';
 my $TIME_SEP = ':';


### PR DESCRIPTION
p5p has recently switched all CORE modules to XSLoader
for performance reasons during the 5.27 development cycle.

Note, XSLoader is a problem for Perl versions earlier than 5.6,
which at this point can get alternate support, as mentioned
in the upstream case.

Upstream-Case: RT #132080
Upstream-URL: https://rt.perl.org/SelfService/Display.html?id=132080