### PR TITLE
Add a travis config to smoke main perl releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+language: "perl"
+sudo: false
+perl:
+  - "5.8"
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+  - "dev"
+  - "blead"
+
+# slows down already cached versions by 3 (33s => 1m45s)
+# (i.e. cache download: 9s, setup: 45s-130s)
+# but speeds up building the non-cached versions (5.24-*) by 2 (3m50s => 1m45s)
+# overall: 25min => 35min, so disable the perl cache
+#cache:
+#  directories:
+#    - /home/travis/perl5/perlbrew/
+
+# blead and 5.6 stumble over YAML and more missing dependencies
+# for Devel::Cover::Report::Coveralls
+# cpanm does not do 5.6
+before_install:
+  - mkdir /home/travis/bin || true
+  - ln -s `which true` /home/travis/bin/cpansign
+  - eval $(curl https://travis-perl.github.io/init) --auto
+install:
+  - export AUTOMATED_TESTING=1 HARNESS_TIMER=1 AUTHOR_TESTING=0 RELEASE_TESTING=0
+  #- cpan-install --deps       # installs prereqs, including recommends
+  #- cpan-install Test::LeakTrace
+  - cpan-install --coverage   # installs converage prereqs, if enabled
+
+before_script:
+  - coverage-setup
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+
+matrix:
+  fast_finish: true
+  include:
+  allow_failures:
+    - env: COVERAGE=1 AUTHOR_TESTING=1
+    - perl: "blead"
+
+# Hack to not run on tag pushes:
+branches:
+  except:
+  - /^v?[0-9]+\.[0-9]+/


### PR DESCRIPTION
Note: Fails on 5.6.2 due to Exporter prereq with
"Exporter version 5.57 required--this is only version 5.562"