### PR TITLE
replace a dead link with a living one.

### DIFF
--- a/Piece.pm
+++ b/Piece.pm
@@ -888,7 +888,7 @@ in perlfunc will still return what you expect.
 
 The module actually implements most of an interface described by
 Larry Wall on the perl5-porters mailing list here:
-L<http://www.xray.mpe.mpg.de/mailing-lists/perl5-porters/2000-01/msg00241.html>
+L<https://www.nntp.perl.org/group/perl.perl5.porters/2000/01/msg5283.html>
 
 =head1 USAGE
 


### PR DESCRIPTION
The link to perl5-porter maling list in the DESCRIPTION section is dead. Luckly the same message is also archived on www.nntp.perl.org.
