### PR TITLE
Add recent test files to MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,10 @@ t/04mjd.t
 t/05overload.t
 t/06subclass.t
 t/07arith.t
+t/08truncate.t
+t/09locales.t
+t/10overload.t
+t/99legacy.t
 t/lib/Time/Piece/Twin.pm
 TODO
 reverse_deps.txt


### PR DESCRIPTION
The four most recent test files were missing from MANIFEST (which appears to be maintained by hand). This PR brings MANIFEST up to date with all the test files included.