### PR TITLE
add plan to t/10overload.t

### DIFF
--- a/t/10overload.t
+++ b/t/10overload.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Time::Piece;
-use Test::More;
+use Test::More tests => 5;
 
 eval 'use Math::BigInt';
 plan skip_all => "Math::BigInt required for testing overloaded operands" if $@;
@@ -21,5 +21,3 @@ is $t->cdate, 'Tue Jan  1 01:00:00 1980', 'add overloaded value';
  
 $t = $t - $big_hour;
 is $t->cdate, 'Tue Jan  1 00:00:00 1980', 'sub overloaded value';
-
-done_testing;


### PR DESCRIPTION
Test::More didn't have a [`done_testing` function](https://metacpan.org/pod/Test::More#done_testing) until v0.87_1 (gitpan/Test-Simple@50dca3a), and Perl didn't ship with a recent enough Test::More until v5.10.1 (Perl/perl5@2a4e024). This fixes the test so it passes on earlier freshly-installed Perls.

I've tested this back to Perl v5.8.9, the earliest that installs on my macOS Monterey 12.5 system.

