### PR TITLE
Cast isdigit argument as unsigned char

### DIFF
--- a/Piece.xs
+++ b/Piece.xs
@@ -843,7 +843,7 @@ label:
 			buf++;
 			i = 0;
 			for (len = 4; len > 0; len--) {
-				if (isdigit((int)*buf)) {
+				if (isdigit((unsigned char)*buf)) {
 					i *= 10;
 					i += *buf - '0';
 					buf++;


### PR DESCRIPTION
Theo noticed that these isdigit calls were not obviously correct. He suggested reporting this upstream.  The only portable safe way is to always cast to (unsigned char).

http://man.openbsd.org/isdigit#CAVEATS
> The argument c must be EOF or representable as an unsigned char;
> otherwise, the result is undefined.

Originally filed as https://github.com/Perl/perl5/pull/20649