### PR TITLE
Piece.xs: eliminate C++ guards

### DIFF
--- a/Piece.xs
+++ b/Piece.xs
@@ -1,14 +1,8 @@
-#ifdef __cplusplus
-extern "C" {
-#endif
 #define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
 #include <time.h>
-#ifdef __cplusplus
-}
-#endif
 
 
 #define    DAYS_PER_YEAR    365


### PR DESCRIPTION
These aren't needed with modern perls, and it's only useful to build modern perls as C++.

This was causing an error in a system header when building blead as C++ with MSVC:

    C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\um\wspiapi.h(53):
    error C2894: templates cannot be declared to have 'C' linkage

See https://github.com/Perl/perl5/issues/21073 for more information