### PR TITLE
Skip week in strftime translation

### DIFF
--- a/Piece.pm
+++ b/Piece.pm
@@ -553,8 +553,10 @@ my $strftime_trans_map = {
     },
     'V' => sub {
         my ( $format, $time ) = @_;
-        my $week = sprintf( "%02d", $time->week() );
-        $format =~ s/%V/$week/ if $IS_WIN32;
+        if ($IS_WIN32) {
+            my $week = sprintf( "%02d", $time->week() );
+            $format =~ s/%V/$week/;
+        }
         return $format;
     },
     'x' => sub {


### PR DESCRIPTION
This PR skip `week()` call in strftime translation except for Win32 platform.

In platform except for Win32, `$week` is not used.