### PR TITLE
RT 133601 Missing semi-colon on Time::Seconds man page

### DIFF
--- a/Seconds.pm
+++ b/Seconds.pm
@@ -226,7 +226,7 @@ seconds only, so you cannot, for example, do this: C<print ONE_WEEK-E<gt>minutes
 
 The following methods are available:
 
-    my $val = Time::Seconds->new(SECONDS)
+    my $val = Time::Seconds->new(SECONDS);
     $val->seconds;
     $val->minutes;
     $val->hours;


### PR DESCRIPTION
A link to the [RT ticket](https://rt.cpan.org/Ticket/Display.html?id=133601)